### PR TITLE
fix: temporarily disable email verification requirement for login

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -61,16 +61,17 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Check if email is verified
-    if (!user.emailVerified) {
-      return NextResponse.json(
-        {
-          error: 'Email not verified',
-          message: 'Please verify your email before logging in',
-        },
-        { status: 403 }
-      );
-    }
+    // TODO: Re-enable email verification once SMTP is configured
+    // For now, allow login without email verification for development
+    // if (!user.emailVerified) {
+    //   return NextResponse.json(
+    //     {
+    //       error: 'Email not verified',
+    //       message: 'Please verify your email before logging in',
+    //     },
+    //     { status: 403 }
+    //   );
+    // }
 
     // Generate tokens
     const accessToken = generateAccessToken(user.id, user.email);


### PR DESCRIPTION
Allow users to log in without email verification while SMTP service is being configured. This unblocks testing and development.

The email verification check will be re-enabled once we set up:
- SMTP service (Resend, SendGrid, etc.)
- Proper email templates
- Verification link handling

Fixes 403 Forbidden error on login for unverified accounts.